### PR TITLE
Test for commands sqlite and sed inside script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You run `nix-store --gc`, and get the error. Easy fix, you enter `nix-shell -p s
 
 Make sure `bash`, `sqlite3` and `sed` are accessibly from your environment.
 
-`DB_PATH` is usually `/nix/car/nix/db/db.sqlite`
+`DB_PATH` is usually `/nix/var/nix/db/db.sqlite`
 
 > [!WARNING]
 > Make a backup of your database first!

--- a/nix-db-cleanup.sh
+++ b/nix-db-cleanup.sh
@@ -6,6 +6,16 @@ if [ $# -ne 2 ]; then
     exit 1
 fi
 
+if ! command -v sqlite3 2>&1 >/dev/null then
+    echo "Error: sqlite3 not in PATH"
+    exit 1
+fi
+
+if ! command -v sed 2>&1 >/dev/null then
+    echo "Error: sed not in PATH"
+    exit 1
+fi
+
 # Path to the SQLite database, usually "/nix/var/nix/db/db.sqlite"
 DB_PATH="$1"
 HASH="$2"


### PR DESCRIPTION
First of all **big thanks** for this wonderful solution to a very annoying problem. I've executed the script after installing sqlite3 and it was all good again. Here's two fixes for it:

- Testing if sqlite3 is available before you actually go into the nitty-gritty of the script is advantageous
- There's a small typo in the README that might confuse users that are in panic mode because their Nix store is "broken"