### PR TITLE
use nix-store --verify --repair

### DIFF
--- a/nix-db-repair.sh
+++ b/nix-db-repair.sh
@@ -35,12 +35,12 @@ extract_hash() {
 
 # Main loop
 while true; do
-    # Run nix-store --gc and capture stderr while discarding stdout
-    error_output=$(nix-store --gc 2>&1 >/dev/null)
+    # Run nix-store --verify --repair and capture stderr while discarding stdout
+    error_output=$(nix-store --verify --repair 2>&1 >/dev/null)
 
     # Check if the error output is empty (meaning no errors occurred)
     if [ -z "$error_output" ]; then
-        echo "nix-store --gc completed successfully."
+        echo "nix-store --verify --repair completed successfully."
         break
     fi
 
@@ -81,4 +81,4 @@ while true; do
     LAST_HASH="$HASH"
 done
 
-echo "All 'nix-store --gc' operations completed."
+echo "All 'nix-store --verify --repair' operations completed."


### PR DESCRIPTION
this is less destructive than `nix-store --gc`

also it seems to find more broken paths, reported as warnings
now these paths are fixed too

`nix-store --verify --repair` prints only warnings for these paths
but `nixos-rebuild switch` throws errors on these paths

i successfully used this script to repair my `/nix/var/nix/db/db.sqlite`
after running [writable-nix-store start](https://github.com/milahu/writable-nix-store) and `nixos-rebuild switch`
see also [how to break your nixos with this tool](https://discourse.nixos.org/t/writable-nix-store/18964/4)

now `nixos-rebuild switch` fails with

> `failed to synthesize: failed to canonicalize /nix/var/nix/profiles/system-102-link: No such file or directory (os error 2)`

but fixing these errors is probably out-of-scope for this tool

these errors are fixed by removing broken symlinks

```sh
#!/usr/bin/env bash
find /nix/var/nix/profiles -maxdepth 1 -name 'system-*-link' -xtype l |
sort -n -t- -k2 -r |
while read -r path; do
  echo "removing broken symlink: $path"
  rm "$path"
done
```
